### PR TITLE
Build with GitHub actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "**" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,23 +23,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
 
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
-    - name: Debug settings.xml
-      run: |
-        echo $(cat ~/.m2/settings.xml)
-        echo $env.GITHUB_ACTOR
+#    - name: 'Create settings.xml'
+#      uses: whelk-io/maven-settings-xml-action@v22
+#      with:
+#        servers: >
+#          [
+#            {
+#              "id": "github",
+#              "username": "${{ secrets.GITHUB_USERNAME }}",
+#              "password": "${{ secrets.GITHUB_PASSWORD }}"
+#            }
+#          ]
+
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
       env:
         GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
+
+    - name: Debug settings.xml
+      run: |
+        echo $(cat ~/.m2/settings.xml)
+        echo $env.GITHUB_ACTOR
+
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     #- name: Update dependency graph

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,22 +30,22 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-        overwrite-settings: false #don't generate settings.xml
+        overwrite-settings: true #generate settings.xml
         cache: maven
 
-    - name: 'Create settings.xml with maven-settings-xml-action'
-      uses: whelk-io/maven-settings-xml-action@v22
-      with:
-        servers: >
-          [
-            {
-              "id": "github",
-              "username": "${{ env.GITHUB_ACTOR }}",
-              "password": "${{ env.GITHUB_TOKEN }}"
-            }
-          ]
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+#    - name: 'Create settings.xml with maven-settings-xml-action'
+#      uses: whelk-io/maven-settings-xml-action@v22
+#      with:
+#        servers: >
+#          [
+#            {
+#              "id": "github",
+#              "username": "${{ env.GITHUB_ACTOR }}",
+#              "password": "${{ env.GITHUB_TOKEN }}"
+#            }
+#          ]
+#      env:
+#        GITHUB_TOKEN: ${{ github.token }}
 
 
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -30,18 +30,22 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
+        overwrite-settings: false #don't generate settings.xml
         cache: maven
-#    - name: 'Create settings.xml'
-#      uses: whelk-io/maven-settings-xml-action@v22
-#      with:
-#        servers: >
-#          [
-#            {
-#              "id": "github",
-#              "username": "${{ secrets.GITHUB_USERNAME }}",
-#              "password": "${{ secrets.GITHUB_PASSWORD }}"
-#            }
-#          ]
+
+    - name: 'Create settings.xml with maven-settings-xml-action'
+      uses: whelk-io/maven-settings-xml-action@v22
+      with:
+        servers: >
+          [
+            {
+              "id": "github",
+              "username": "${{ env.GITHUB_ACTOR }}",
+              "password": "${{ env.GITHUB_TOKEN }}"
+            }
+          ]
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
 
 
     - name: Build with Maven
@@ -52,7 +56,7 @@ jobs:
     - name: Debug settings.xml
       run: |
         echo $(cat ~/.m2/settings.xml)
-        echo $env.GITHUB_ACTOR
+        echo "GITHUB_ACTOR=${{ env.GITHUB_ACTOR }}"
 
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive

--- a/cdoc2-client/pom.xml
+++ b/cdoc2-client/pom.xml
@@ -18,30 +18,10 @@
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
 
         <spotbugs-annotations.version>4.8.5</spotbugs-annotations.version>
+
         <!--info.version from cdoc2-openapi/cdoc2-key-capsules-openapi.yaml -->
         <cdoc2-key-capsules-openapi.version>2.1.0</cdoc2-key-capsules-openapi.version>
-        <!--maven.repository.url>https://maven.pkg.github.com/jann0k/cdoc2-java-ref-impl</maven.repository.url-->
     </properties>
-
-    <!--repositories>
-        <repository>
-            <id>gitlab.ext.cyber.ee</id>
-            <url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>gitlab.ext.cyber.ee</id>
-            <url>https://gitlab.ext.cyber.ee/api/v4/projects/40/packages/maven</url>
-        </repository>
-
-        <snapshotRepository>
-            <id>gitlab.ext.cyber.ee</id>
-            <url>https://gitlab.ext.cyber.ee/api/v4/projects/40/packages/maven</url>
-        </snapshotRepository>
-    </distributionManagement-->
-
 
     <dependencies>
         <dependency>

--- a/cdoc2-client/pom.xml
+++ b/cdoc2-client/pom.xml
@@ -137,8 +137,6 @@
                             <artifactId>cdoc2-key-capsules-openapi</artifactId>
                             <version>${cdoc2-key-capsules-openapi.version}</version>
                             <packaging>yaml</packaging>
-                            <!-- can be removed when copied to cdoc2-java-ref-impl repo -->
-                            <!--remoteRepositories>${maven.repository.url}</remoteRepositories-->
                         </configuration>
                     </execution>
 

--- a/cdoc2-client/pom.xml
+++ b/cdoc2-client/pom.xml
@@ -20,10 +20,10 @@
         <spotbugs-annotations.version>4.8.5</spotbugs-annotations.version>
         <!--info.version from cdoc2-openapi/cdoc2-key-capsules-openapi.yaml -->
         <cdoc2-key-capsules-openapi.version>2.1.0</cdoc2-key-capsules-openapi.version>
-        <maven.repository.url>gitlab.ext.cyber.ee::::https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</maven.repository.url>
+        <!--maven.repository.url>https://maven.pkg.github.com/jann0k/cdoc2-java-ref-impl</maven.repository.url-->
     </properties>
 
-    <repositories>
+    <!--repositories>
         <repository>
             <id>gitlab.ext.cyber.ee</id>
             <url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
@@ -40,7 +40,7 @@
             <id>gitlab.ext.cyber.ee</id>
             <url>https://gitlab.ext.cyber.ee/api/v4/projects/40/packages/maven</url>
         </snapshotRepository>
-    </distributionManagement>
+    </distributionManagement-->
 
 
     <dependencies>
@@ -158,7 +158,7 @@
                             <version>${cdoc2-key-capsules-openapi.version}</version>
                             <packaging>yaml</packaging>
                             <!-- can be removed when copied to cdoc2-java-ref-impl repo -->
-                            <remoteRepositories>${maven.repository.url}</remoteRepositories>
+                            <!--remoteRepositories>${maven.repository.url}</remoteRepositories-->
                         </configuration>
                     </execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,33 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <!-- activate github profile when runned by github actions -->
+            <id>github</id>
+            <activation>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/open-eid/cdoc2-capsule-server</url>
+                </repository>
+            </repositories>
+        </profile>
+
+        <!--profile>
+            <id>gitlab.ext</id>
+            <repositories>
+                <repository>
+                    <id>gitlab.ext.cyber.ee</id>
+                    <url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
+                </repository>
+            </repositories>
+        </profile-->
     </profiles>
 
     <repositories>
@@ -95,10 +122,10 @@
             <id>github</id>
             <url>https://maven.pkg.github.com/jann0k/cdoc2-java-ref-impl</url>
         </repository-->
-        <repository>
+        <!--repository>
             <id>github</id>
             <url>https://maven.pkg.github.com/open-eid/cdoc2-capsule-server</url>
-        </repository>
+        </repository-->
 	</repositories>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,27 +86,23 @@
         </profile>
     </profiles>
 
-    <!-- Configuration for Maven Release plugin -->
-    <scm>
-      <connection>scm:git:${project.scm.url}</connection>
-        <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>git@github.com:jann0k/cdoc2-java-ref-impl-private.git</url>
-      <tag>HEAD</tag>
-  </scm>
-
     <repositories>
         <!--repository>
 			<id>gitlab.ext.cyber.ee</id>
 			<url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
 		</repository-->
-        <repository>
+        <!--repository>
             <id>github</id>
             <url>https://maven.pkg.github.com/jann0k/cdoc2-java-ref-impl</url>
+        </repository-->
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/open-eid/cdoc2-capsule-server</url>
         </repository>
 	</repositories>
 
 
-    <distributionManagement>
+    <!--distributionManagement>
         <repository>
             <id>github</id>
             <name>GitHub jann0k Maven Packages</name>
@@ -118,7 +114,7 @@
             <name>GitHub jann0k Maven Packages</name>
             <url>https://maven.pkg.github.com/jann0k/cdoc2-java-ref-impl</url>
         </snapshotRepository>
-    </distributionManagement>
+    </distributionManagement-->
 
 
     <!--distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -95,13 +95,33 @@
   </scm>
 
     <repositories>
-        <repository>
+        <!--repository>
 			<id>gitlab.ext.cyber.ee</id>
 			<url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
-		</repository>
+		</repository-->
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/jann0k/cdoc2-java-ref-impl</url>
+        </repository>
 	</repositories>
 
-	<distributionManagement>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub jann0k Maven Packages</name>
+            <url>https://maven.pkg.github.com/jann0k/cdoc2-java-ref-impl</url>
+        </repository>
+
+        <snapshotRepository>
+            <id>github</id>
+            <name>GitHub jann0k Maven Packages</name>
+            <url>https://maven.pkg.github.com/jann0k/cdoc2-java-ref-impl</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+
+    <!--distributionManagement>
         <repository>
 			<id>gitlab.ext.cyber.ee</id>
 			<url>https://gitlab.ext.cyber.ee/api/v4/projects/40/packages/maven</url>
@@ -111,7 +131,7 @@
 			<id>gitlab.ext.cyber.ee</id>
 			<url>https://gitlab.ext.cyber.ee/api/v4/projects/40/packages/maven</url>
 		</snapshotRepository>
-	</distributionManagement>
+	</distributionManagement-->
 
     <modules>
         <module>cdoc2-schema</module>


### PR DESCRIPTION
Build cdoc2-java-ref-impl with GitHub Actions

* Update Maven remoteRepository to https://maven.pkg.github.com/open-eid/cdoc2-capsule in pom.xml
* Requires [ee.cyber.cdoc2.openapi:cdoc2-key-capsules-openapi](https://github.com/open-eid/cdoc2-capsule-server/packages/2217039?version=2.1.0)

cdoc2-key-capsules-openapi was manually pushed to Maven repo:

```
git clone git@github.com:open-eid/cdoc2-capsule-server.git
cd cdoc2-capsule-server
mvn -f cdoc2-openapi deploy -Dcodegen.skip=true -Dmaven.deploy.skip=true -Dmaven.repository.id=github -Dmaven.repository.url=https://maven.pkg.github.com/open-eid/cdoc2-capsule-server
```
