### PR TITLE
Add GitHub release workflow (publish Maven packages)

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,30 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Publish to GitHub Packages Apache Maven (Maven repository)
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Publish to GitHub Packages Apache Maven
+        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
                     <!-- When pulling, the package index is based on the organization level, not the repository level. -->
                     <!-- Although GITHUB_REPOSITORY contains repo, all organization packages are indexed there -->
                     <!-- https://stackoverflow.com/questions/63041402/github-packages-single-maven-repository-for-github-organization -->
+                    <!--suppress UnresolvedMavenProperty -->
                     <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
                 </repository>
 
@@ -109,10 +110,12 @@
             <distributionManagement>
                 <repository>
                     <id>github</id>
+                    <!--suppress UnresolvedMavenProperty -->
                     <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
                 </repository>
                 <snapshotRepository>
                     <id>github</id>
+                    <!--suppress UnresolvedMavenProperty -->
                     <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
                 </snapshotRepository>
             </distributionManagement>
@@ -135,10 +138,12 @@
                 <!-- env variables are available, when run by gitlab CI -->
                 <repository>
                     <id>gitlab.ext.cyber.ee</id>
+                    <!--suppress UnresolvedMavenProperty -->
                     <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
                 </repository>
                 <snapshotRepository>
                     <id>gitlab.ext.cyber.ee</id>
+                    <!--suppress UnresolvedMavenProperty -->
                     <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
                 </snapshotRepository>
             </distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,19 @@
                     <!-- https://stackoverflow.com/questions/63041402/github-packages-single-maven-repository-for-github-organization -->
                     <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
                 </repository>
+
             </repositories>
+            <distributionManagement>
+                <repository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+                </repository>
+                <snapshotRepository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+                </snapshotRepository>
+            </distributionManagement>
+
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -137,12 +137,12 @@
             <distributionManagement>
                 <!-- env variables are available, when run by gitlab CI -->
                 <repository>
-                    <id>gitlab.ext.cyber.ee</id>
+                    <id>${env.CI_SERVER_HOST}</id>
                     <!--suppress UnresolvedMavenProperty -->
                     <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
                 </repository>
                 <snapshotRepository>
-                    <id>gitlab.ext.cyber.ee</id>
+                    <id>${env.CI_SERVER_HOST}</id>
                     <!--suppress UnresolvedMavenProperty -->
                     <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
                 </snapshotRepository>


### PR DESCRIPTION
- Add `maven-release.yml` GH workflow file that publishes Maven packages when release is made
- Update main `pom.xml` to include `distributionManagement` for `github_ci`
- Tested here https://github.com/jann0k/cdoc2-java-ref-impl/actions/runs/10283441892 