### PR TITLE
Prepare cdoc2-java-ref-impl version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,29 @@
 # Changelog
 
-## [1.4.0] Key label formatting (2024-XX-XX)
+## [1.4.0] Key label formatting (2024-09-02)
+
+### Features
+
+* Support for [machine-readable KeyLabel format](https://open-eid.github.io/CDOC2/1.1/02_protocol_and_cryptography_spec/appendix_d_keylabel/)
+  - When encrypting, then this formatted key label is enabled by default. Can be disabled by setting `ee.cyber.cdoc2.key-label.machine-readable-format.enabled=false` system property (`-D`)
+  - When decrypting, then both formatted and unformatted key label field versions are supported.
+
+### Bug Fixes
+
+* Fix cdoc2-cli encrypting functionality for SymmetricKey (`--secret` parameter). Bug was introduced with 1.1.0 release
+  - Rewrote symmetric key (secret) and password handling in cdoc2-cli/cdoc2-lib
+  - Bumped cdoc2-lib major version to `2.0.0`, as broken classes (`FormattedOptionParts`) were removed and replaced with a new ones (`LabeledPassword` and `LabeledSecret`)
+  - cdoc2-lib was not broken, when using `EncryptionKeyMaterial#fromSecret(SecretKey,String)` directly (without `FormattedOptionParts`)
+  - broken example cdoc2 files were removed from `test/testvectors` and replaced with a correct ones
+* Fix cdoc2-client ApiClient timeouts (`cdoc2.client.server.*-timeout` were not working)
+* Allow loading [pkcs11 (smart-card) test properties](README.md#pkcs11-tests) from file system (previously only classpath was working)
 
 ### Internal
 
-* Upgraded Spring 3.2.5 -> 3.3.3 + other third-party dependency updates
+* Third-party dependency updates to latest
+* Added GitHub workflows for building and releasing
+* Resolve issues reported by SonarCloud/SonarQube
+* Update client and server certificates used for unit-tests. Add scripts for future updates
 
 ## [1.3.0] '/key-capsules' OAS v2.1.0 support (2024-07-02)
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -53,7 +53,7 @@ General release procedure:
 * `prepare_release.sh` (changes versions to RELEASE versions and runs tests)
 * Verify changes (`git diff`)
 * Edit CHANGELOG.md
-* `make_release.sh` (`git commit; git push` RELEASE branch and `mvn deploy` RELEASE artifacts)
+* `make_release.sh -d` (`git commit; git push` to RELEASE branch)
 
 This will change -SNAPSHOT version to release version, update dependencies in all modules to latest
 non-SNAPSHOT version. Build, test, create release branch, push changes, deploy maven artifacts.
@@ -64,8 +64,8 @@ version in parent pom before changing other versions.
 
 If everything went well, then
 * release branch was created with name 'release_v<parent-pom.version>'
-* Maven artifacts with release version are in Maven repository
 * original branch is checked out ('master' usually)
+* Nothing is commited to main branch ('master')
 
 To finish create squash merge from release branch to main branch
 ```bash
@@ -73,6 +73,10 @@ git merge --squash $RELEASE_BRANCH
 git commit -m "Squashed commit from $RELEASE_BRANCH"
 git push $GIT_REMOTE $GIT_BRANCH
 ```
+
+or create GitHub PR (recommended) from release branch and merge from GitHub. 
+
+Finish by [publishing](README.md#publishing) deliverables from a release tag.
 
 ### Release cdoc2-java-ref-impl and cdoc2-capsule-server
 

--- a/cdoc2-cli/pom.xml
+++ b/cdoc2-cli/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>cdoc2</artifactId>
         <groupId>ee.cyber.cdoc2</groupId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
     </parent>
 
     <artifactId>cdoc2-cli</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
     <description>Command line utility to create/process CDOC2 files</description>
 
     <properties>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>ee.cyber.cdoc2</groupId>
             <artifactId>cdoc2-lib</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.0.0</version>
         </dependency>
     </dependencies>
 

--- a/cdoc2-client/pom.xml
+++ b/cdoc2-client/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>cdoc2</artifactId>
         <groupId>ee.cyber.cdoc2</groupId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
     </parent>
 
     <artifactId>cdoc2-client</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
     <description>CDOC2 server client generation from openapi specification</description>
 
     <properties>

--- a/cdoc2-lib/pom.xml
+++ b/cdoc2-lib/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>cdoc2</artifactId>
         <groupId>ee.cyber.cdoc2</groupId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cdoc2-lib</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
     <description>CDOC2 creation and processing library</description>
 
     <properties>
@@ -20,13 +20,13 @@
         <dependency>
             <groupId>ee.cyber.cdoc2</groupId>
             <artifactId>cdoc2-schema</artifactId>
-            <version>1.3.0-SNAPSHOT</version>
+            <version>1.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>ee.cyber.cdoc2</groupId>
             <artifactId>cdoc2-client</artifactId>
-            <version>1.5.0-SNAPSHOT</version>
+            <version>1.5.0</version>
         </dependency>
 
         <dependency>

--- a/cdoc2-schema/pom.xml
+++ b/cdoc2-schema/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
         <groupId>ee.cyber.cdoc2</groupId>
         <artifactId>cdoc2</artifactId>
     </parent>
 
     <artifactId>cdoc2-schema</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
 
     <description>CDOC2 flatbuffer schemas and related functionality </description>
 

--- a/make_release.sh
+++ b/make_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -o xtrace
+#set -o xtrace
 # git commit
 # git tag
 # git push

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
     <groupId>ee.cyber.cdoc2</groupId>
     <artifactId>cdoc2</artifactId>
     <description>CDOC2 reference implementation </description>

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -34,5 +34,9 @@ done
 
 # replace module -SNAPSHOT version with release version (non-SNAPSHOT)
 mvn versions:set -DremoveSnapshot
+mvn versions:set -DremoveSnapshot -pl cdoc2-schema
+mvn versions:set -DremoveSnapshot -pl cdoc2-client
+mvn versions:set -DremoveSnapshot -pl cdoc2-lib
+mvn versions:set -DremoveSnapshot -pl cdoc2-cli
 # build and install into local maven package repository
 mvn install


### PR DESCRIPTION
* Prepare cdoc2-java-ref-impl version 1.4.0
* For some reason GH workflow is not triggered. Its triggered for fork https://github.com/open-eid/cdoc2-java-ref-impl/pull/9