### PR TITLE
Fix bug in KekTools that causes RSA crypto sticks to not work for local decryption

### DIFF
--- a/cdoc2-lib/src/main/java/ee/cyber/cdoc2/crypto/KekTools.java
+++ b/cdoc2-lib/src/main/java/ee/cyber/cdoc2/crypto/KekTools.java
@@ -241,8 +241,16 @@ public final class KekTools {
             throw new IllegalArgumentException(MUST_CONTAIN_RSA_KEY_PAIR_FOR_RSA_SCENARIO);
         }
 
-        RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) recipientKeyPair.getPrivate();
-        return RsaUtils.rsaDecrypt(rsaPubKeyRecipient.getEncryptedKek(), rsaPrivateKey);
+        byte[] encryptedKek = rsaPubKeyRecipient.getEncryptedKek();
+
+        PrivateKey privateKey = recipientKeyPair.getPrivate();
+        RSAPrivateKey rsaPrivateKey;
+        if (privateKey instanceof RSAPrivateKey) {
+            rsaPrivateKey = (RSAPrivateKey) privateKey;
+            return RsaUtils.rsaDecrypt(encryptedKek, rsaPrivateKey);
+        } else {
+            return DirectPKCS11Wrapper.rsaDecryptPKCS11(encryptedKek);
+        }
     }
 
     private static void validateKeyOrigin(


### PR DESCRIPTION
The KekTools.java is missing the needed code in the method `deriveKekForRsa()` for handling RSA crypto sticks.

Signed-off-by: Hain Zuppur hain.zuppur@cyber.ee
