### PR TITLE
CDOC-41: Add correct value to zetes ldap base dn

### DIFF
--- a/cdoc2-lib/src/main/java/ee/cyber/cdoc2/util/ZetesLdapUtil.java
+++ b/cdoc2-lib/src/main/java/ee/cyber/cdoc2/util/ZetesLdapUtil.java
@@ -43,7 +43,7 @@ public final class ZetesLdapUtil extends EstEidLdapUtil {
 
         @Override
         public String getBaseDn() {
-            return "dc=ESTEID,c=EE,dc=eidpki,dc=ee";
+            return "dc=ldap,dc=eidpki,dc=ee";
         }
 
         @Override


### PR DESCRIPTION
The BaseDn for live Zetes LDAP server is different than the test Zetes LDAP BaseDn.

Added the correct value for live Zetes LDAP baseDn.